### PR TITLE
Update for redux-offline v2.0.0

### DIFF
--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,18 +1,17 @@
-import { applyMiddleware } from 'redux';
-import { createOfflineStore } from 'redux-offline';
+import { applyMiddleware, createStore, compose } from 'redux';
+import { offline } from 'redux-offline';
+import offlineConfig from 'redux-offline/lib/defaults';
 import createLogger from 'redux-logger';
 
 import reducer from './reducer';
 
-const options = {
-  rehydrate: true
-};
-
-const store = createOfflineStore(
+const store = createStore(
   reducer,
   undefined,
-  applyMiddleware(createLogger({ collapsed: true })),
-  options
+  compose(
+    applyMiddleware(createLogger({ collapsed: true })),
+    offline(offlineConfig)
+  ),
 );
 
 export default store;


### PR DESCRIPTION
The example is currently broken. This simple change brings fixes breaking changes as of redux-offline v2.0.0.

See [migration guide](https://github.com/jevakallio/redux-offline/releases/tag/v2.0.0).